### PR TITLE
Integrate JavaFX user admin with backend services

### DIFF
--- a/backend/src/main/java/com/cbtis239/escolares/service/UserService.java
+++ b/backend/src/main/java/com/cbtis239/escolares/service/UserService.java
@@ -10,6 +10,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -51,6 +52,14 @@ public class UserService {
     @Transactional(readOnly = true)
     public java.util.List<UserDto> list() {
         return userRepo.findAll().stream().map(this::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public java.util.List<com.cbtis239.escolares.web.dto.RoleDto> listRoles() {
+        return roleRepo.findAll().stream()
+                .map(role -> new com.cbtis239.escolares.web.dto.RoleDto(role.getId(), role.getName()))
+                .sorted(Comparator.comparing(com.cbtis239.escolares.web.dto.RoleDto::name, String.CASE_INSENSITIVE_ORDER))
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/com/cbtis239/escolares/web/UserController.java
+++ b/backend/src/main/java/com/cbtis239/escolares/web/UserController.java
@@ -29,6 +29,11 @@ public class UserController {
         return ResponseEntity.ok(service.list());
     }
 
+    @GetMapping("/roles")
+    public ResponseEntity<java.util.List<RoleDto>> listRoles() {
+        return ResponseEntity.ok(service.listRoles());
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<UserDto> update(@PathVariable Long id, @RequestBody UserUpdateRequest req) {
         return ResponseEntity.ok(service.update(id, req));

--- a/backend/src/main/java/com/cbtis239/escolares/web/dto/RoleDto.java
+++ b/backend/src/main/java/com/cbtis239/escolares/web/dto/RoleDto.java
@@ -1,0 +1,3 @@
+package com.cbtis239.escolares.web.dto;
+
+public record RoleDto(Long id, String name) {}

--- a/front/build.gradle
+++ b/front/build.gradle
@@ -23,6 +23,9 @@ dependencies {
   // JavaFX (usa solo una versión coherente)
   implementation 'org.openjfx:javafx-controls:21.0.4'
   implementation 'org.openjfx:javafx-fxml:21.0.4'
+
+  // Cliente HTTP y JSON
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
 }
 
 javafx {

--- a/front/src/main/java/cbtis239/front/api/ApiException.java
+++ b/front/src/main/java/cbtis239/front/api/ApiException.java
@@ -1,0 +1,14 @@
+package cbtis239.front.api;
+
+public class ApiException extends RuntimeException {
+    private final int statusCode;
+
+    public ApiException(int statusCode, String message) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/front/src/main/java/cbtis239/front/api/UserApiClient.java
+++ b/front/src/main/java/cbtis239/front/api/UserApiClient.java
@@ -1,0 +1,131 @@
+package cbtis239.front.api;
+
+import cbtis239.front.api.dto.RoleDto;
+import cbtis239.front.api.dto.UserCreateRequest;
+import cbtis239.front.api.dto.UserDto;
+import cbtis239.front.api.dto.UserUpdateRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+public class UserApiClient {
+    private static final TypeReference<List<UserDto>> USER_LIST_REF = new TypeReference<>() {};
+    private static final TypeReference<List<RoleDto>> ROLE_LIST_REF = new TypeReference<>() {};
+
+    private final HttpClient client;
+    private final ObjectMapper mapper;
+    private final String baseUrl;
+
+    public UserApiClient() {
+        this(HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build(),
+                defaultBaseUrl());
+    }
+
+    public UserApiClient(HttpClient client, String baseUrl) {
+        this.client = client;
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        this.mapper = new ObjectMapper().findAndRegisterModules();
+    }
+
+    private static String defaultBaseUrl() {
+        return Optional.ofNullable(System.getenv("API_BASE_URL"))
+                .orElseGet(() -> System.getProperty("api.base-url", "http://localhost:8080/api"));
+    }
+
+    public List<UserDto> listUsers() {
+        HttpRequest request = baseRequest("/usuarios").GET().build();
+        String body = send(request, 200);
+        try {
+            return mapper.readValue(body, USER_LIST_REF);
+        } catch (JsonProcessingException e) {
+            throw new ApiException(500, "Error al parsear usuarios: " + e.getMessage());
+        }
+    }
+
+    public UserDto createUser(UserCreateRequest requestBody) {
+        HttpRequest request = baseRequest("/usuarios")
+                .POST(HttpRequest.BodyPublishers.ofString(writeBody(requestBody), StandardCharsets.UTF_8))
+                .header("Content-Type", "application/json")
+                .build();
+        String body = send(request, 201);
+        try {
+            return mapper.readValue(body, UserDto.class);
+        } catch (JsonProcessingException e) {
+            throw new ApiException(500, "Error al parsear la respuesta de creación: " + e.getMessage());
+        }
+    }
+
+    public UserDto updateUser(long id, UserUpdateRequest requestBody) {
+        HttpRequest request = baseRequest("/usuarios/" + id)
+                .PUT(HttpRequest.BodyPublishers.ofString(writeBody(requestBody), StandardCharsets.UTF_8))
+                .header("Content-Type", "application/json")
+                .build();
+        String body = send(request, 200);
+        try {
+            return mapper.readValue(body, UserDto.class);
+        } catch (JsonProcessingException e) {
+            throw new ApiException(500, "Error al parsear la respuesta de actualización: " + e.getMessage());
+        }
+    }
+
+    public void deleteUser(long id) {
+        HttpRequest request = baseRequest("/usuarios/" + id)
+                .DELETE()
+                .build();
+        send(request, 204);
+    }
+
+    public List<RoleDto> listRoles() {
+        HttpRequest request = baseRequest("/usuarios/roles").GET().build();
+        String body = send(request, 200);
+        try {
+            return mapper.readValue(body, ROLE_LIST_REF);
+        } catch (JsonProcessingException e) {
+            throw new ApiException(500, "Error al parsear roles: " + e.getMessage());
+        }
+    }
+
+    private HttpRequest.Builder baseRequest(String path) {
+        String normalized = path.startsWith("/") ? path : "/" + path;
+        return HttpRequest.newBuilder(URI.create(baseUrl + normalized))
+                .timeout(Duration.ofSeconds(10))
+                .header("Accept", "application/json")
+                .header("Accept-Language", Locale.getDefault().toLanguageTag());
+    }
+
+    private String send(HttpRequest request, int expectedStatus) {
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            if (response.statusCode() != expectedStatus) {
+                throw new ApiException(response.statusCode(), response.body());
+            }
+            return response.body();
+        } catch (IOException e) {
+            throw new ApiException(500, "Error de comunicación con el backend: " + e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ApiException(500, "Solicitud interrumpida");
+        }
+    }
+
+    private String writeBody(Object value) {
+        try {
+            return mapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new ApiException(500, "No se pudo serializar la petición: " + e.getMessage());
+        }
+    }
+}

--- a/front/src/main/java/cbtis239/front/api/dto/RoleDto.java
+++ b/front/src/main/java/cbtis239/front/api/dto/RoleDto.java
@@ -1,0 +1,3 @@
+package cbtis239.front.api.dto;
+
+public record RoleDto(Long id, String name) {}

--- a/front/src/main/java/cbtis239/front/api/dto/UserCreateRequest.java
+++ b/front/src/main/java/cbtis239/front/api/dto/UserCreateRequest.java
@@ -1,0 +1,5 @@
+package cbtis239.front.api.dto;
+
+import java.util.Set;
+
+public record UserCreateRequest(String fullName, String email, String password, Set<String> roles) {}

--- a/front/src/main/java/cbtis239/front/api/dto/UserDto.java
+++ b/front/src/main/java/cbtis239/front/api/dto/UserDto.java
@@ -1,0 +1,5 @@
+package cbtis239.front.api.dto;
+
+import java.util.Set;
+
+public record UserDto(Long id, String fullName, String email, Set<String> roles, Boolean active) {}

--- a/front/src/main/java/cbtis239/front/api/dto/UserUpdateRequest.java
+++ b/front/src/main/java/cbtis239/front/api/dto/UserUpdateRequest.java
@@ -1,0 +1,5 @@
+package cbtis239.front.api.dto;
+
+import java.util.Set;
+
+public record UserUpdateRequest(String fullName, Boolean active, Set<String> roles) {}

--- a/front/src/main/java/cbtis239/front/ui/users/UserFxModel.java
+++ b/front/src/main/java/cbtis239/front/ui/users/UserFxModel.java
@@ -1,0 +1,155 @@
+package cbtis239.front.ui.users;
+
+import cbtis239.front.api.dto.UserDto;
+import javafx.beans.property.LongProperty;
+import javafx.beans.property.SimpleLongProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class UserFxModel {
+    private final LongProperty id = new SimpleLongProperty();
+    private final StringProperty email = new SimpleStringProperty();
+    private final StringProperty nombres = new SimpleStringProperty();
+    private final StringProperty apellidoPat = new SimpleStringProperty();
+    private final StringProperty apellidoMat = new SimpleStringProperty();
+    private final StringProperty roles = new SimpleStringProperty();
+
+    private Set<String> roleSet = new LinkedHashSet<>();
+
+    public static UserFxModel fromDto(UserDto dto) {
+        UserFxModel model = new UserFxModel();
+        model.updateFromDto(dto);
+        return model;
+    }
+
+    public void updateFromDto(UserDto dto) {
+        if (dto.id() != null) {
+            setId(dto.id());
+        }
+        setEmail(dto.email());
+        setRoles(dto.roles() == null ? Set.of() : dto.roles());
+        setFullName(dto.fullName());
+    }
+
+    public void setFullName(String fullName) {
+        if (fullName == null || fullName.isBlank()) {
+            setNombres("");
+            setApellidoPat("");
+            setApellidoMat("");
+            return;
+        }
+        String[] parts = fullName.trim().split("\\s+");
+        if (parts.length == 1) {
+            setNombres(parts[0]);
+            setApellidoPat("");
+            setApellidoMat("");
+        } else if (parts.length == 2) {
+            setNombres(parts[0]);
+            setApellidoPat(parts[1]);
+            setApellidoMat("");
+        } else {
+            setNombres(parts[0]);
+            setApellidoPat(parts[1]);
+            setApellidoMat(String.join(" ", Arrays.copyOfRange(parts, 2, parts.length)));
+        }
+    }
+
+    public LongProperty idProperty() {
+        return id;
+    }
+
+    public long getId() {
+        return id.get();
+    }
+
+    public void setId(long value) {
+        this.id.set(value);
+    }
+
+    public StringProperty emailProperty() {
+        return email;
+    }
+
+    public String getEmail() {
+        return email.get();
+    }
+
+    public void setEmail(String value) {
+        this.email.set(value);
+    }
+
+    public StringProperty nombresProperty() {
+        return nombres;
+    }
+
+    public String getNombres() {
+        return nombres.get();
+    }
+
+    public void setNombres(String value) {
+        this.nombres.set(value);
+    }
+
+    public StringProperty apellidoPatProperty() {
+        return apellidoPat;
+    }
+
+    public String getApellidoPat() {
+        return apellidoPat.get();
+    }
+
+    public void setApellidoPat(String value) {
+        this.apellidoPat.set(value);
+    }
+
+    public StringProperty apellidoMatProperty() {
+        return apellidoMat;
+    }
+
+    public String getApellidoMat() {
+        return apellidoMat.get();
+    }
+
+    public void setApellidoMat(String value) {
+        this.apellidoMat.set(value);
+    }
+
+    public StringProperty rolesProperty() {
+        return roles;
+    }
+
+    public String getRolesText() {
+        return roles.get();
+    }
+
+    public void setRoles(Set<String> roles) {
+        java.util.List<String> normalized = (roles == null ? Set.<String>of() : roles).stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .sorted(String::compareToIgnoreCase)
+                .toList();
+        this.roleSet = new LinkedHashSet<>(normalized);
+        this.roles.set(String.join(", ", normalized));
+    }
+
+    public Set<String> getRoleSet() {
+        return roleSet;
+    }
+
+    public String getPrimaryRole() {
+        return roleSet.stream().findFirst().orElse(null);
+    }
+
+    public String getFullName() {
+        return Arrays.asList(getNombres(), getApellidoPat(), getApellidoMat()).stream()
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.joining(" "));
+    }
+}

--- a/front/src/main/java/module-info.java
+++ b/front/src/main/java/module-info.java
@@ -2,9 +2,17 @@ module cbtis239.front {
     requires javafx.controls;
     requires javafx.fxml;
 
+    requires java.net.http;
+    requires com.fasterxml.jackson.databind;
+    requires com.fasterxml.jackson.core;
+    requires com.fasterxml.jackson.annotation;
+
     requires org.kordamp.ikonli.core;
     requires org.kordamp.ikonli.javafx;
 
     opens cbtis239.front to javafx.fxml;
+    opens cbtis239.front.ui.users to javafx.fxml;
+    opens cbtis239.front.api.dto to com.fasterxml.jackson.databind;
+
     exports cbtis239.front;
 }


### PR DESCRIPTION
## Summary
- expose the backend role list so the UI can discover available roles
- add a reusable HTTP client layer in the JavaFX app for talking to the Spring API
- rework the register-user screen to load roles, CRUD users, and keep the table in sync with backend data

## Testing
- sh gradlew -p front check *(fails: Gradle wrapper cannot download the distribution because outbound network/proxy access is blocked in the CI environment)*
- sh mvnw -DskipTests package *(fails: Maven wrapper cannot download Maven due to the same proxy restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68e59fb17b40832da4ccb1e9f73c649c